### PR TITLE
WIP: add support for preview 2 components that target the wasi:cli world

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,12 +77,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,18 +473,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
-name = "chrono"
-version = "0.4.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
-dependencies = [
- "android-tzdata",
- "iana-time-zone",
- "num-traits",
- "windows-targets 0.52.4",
-]
-
-[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,17 +732,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "cron"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8c3e73077b4b4a6ab1ea5047c37c57aee77657bc8ecd6f29b0af082d0b0c07"
-dependencies = [
- "chrono",
- "nom",
- "once_cell",
 ]
 
 [[package]]
@@ -2453,17 +2424,6 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num-derive"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "num-integer"
@@ -4651,21 +4611,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-cron-scheduler"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de2c1fd54a857b29c6cd1846f31903d0ae8e28175615c14a277aed45c58d8e27"
-dependencies = [
- "chrono",
- "cron",
- "num-derive",
- "num-traits",
- "tokio",
- "tracing",
- "uuid",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4981,7 +4926,6 @@ dependencies = [
  "spin-core",
  "spin-trigger",
  "tokio",
- "tokio-cron-scheduler",
  "tracing",
  "tracing-subscriber",
  "wasmtime-wasi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1174,6 +1174,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1674,10 +1685,10 @@ dependencies = [
  "http 0.2.12",
  "hyper 0.14.28",
  "log",
- "rustls",
- "rustls-native-certs",
+ "rustls 0.21.10",
+ "rustls-native-certs 0.6.3",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "webpki-roots",
 ]
 
@@ -2582,10 +2593,106 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d57987be3f2aeb70d385fff9b27fb74c5723cc9a52d904d4f9c807a0667bf"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+ "urlencoding",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cbfa5308166ca861434f0b0913569579b8e587430a3d6bcd7fd671921ec145a"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 0.2.12",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a016b8d9495c639af2145ac22387dcb88e44118e45320d9238fbf4e7889abcb"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http 0.2.12",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8fddc9b68f5b80dae9d6f510b88e02396f006ad48cac349411fbecc80caae4"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9ab5bd6c42fb9349dcf28af2ba9a0667f697f9bdcca045d39f2cec5543e2910"
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e90c7113be649e31e9a0f8b5ee24ed7a16923b322c3c5ab6367469c049d6b7e"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "once_cell",
+ "opentelemetry",
+ "ordered-float",
+ "percent-encoding",
+ "rand 0.8.5",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "os_str_bytes"
@@ -2620,14 +2727,15 @@ dependencies = [
 
 [[package]]
 name = "outbound-http"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0-pre0"
+source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
 dependencies = [
  "anyhow",
  "http 0.2.12",
  "reqwest",
  "spin-app",
  "spin-core",
+ "spin-expressions",
  "spin-locked-app",
  "spin-outbound-networking",
  "spin-world",
@@ -2637,9 +2745,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "outbound-mqtt"
+version = "2.4.0-pre0"
+source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
+dependencies = [
+ "anyhow",
+ "rumqttc",
+ "spin-app",
+ "spin-core",
+ "spin-expressions",
+ "spin-outbound-networking",
+ "spin-world",
+ "table",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "outbound-mysql"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0-pre0"
+source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
 dependencies = [
  "anyhow",
  "flate2",
@@ -2647,6 +2772,7 @@ dependencies = [
  "mysql_common",
  "spin-app",
  "spin-core",
+ "spin-expressions",
  "spin-outbound-networking",
  "spin-world",
  "table",
@@ -2657,14 +2783,15 @@ dependencies = [
 
 [[package]]
 name = "outbound-pg"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0-pre0"
+source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
 dependencies = [
  "anyhow",
  "native-tls",
  "postgres-native-tls",
  "spin-app",
  "spin-core",
+ "spin-expressions",
  "spin-outbound-networking",
  "spin-world",
  "table",
@@ -2675,13 +2802,14 @@ dependencies = [
 
 [[package]]
 name = "outbound-redis"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0-pre0"
+source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
 dependencies = [
  "anyhow",
  "redis",
  "spin-app",
  "spin-core",
+ "spin-expressions",
  "spin-outbound-networking",
  "spin-world",
  "table",
@@ -2971,6 +3099,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
 name = "psm"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3221,8 +3372,8 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
- "rustls-pemfile",
+ "rustls 0.21.10",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -3230,7 +3381,7 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tokio-util 0.7.10",
  "tower-service",
  "url",
@@ -3255,6 +3406,25 @@ dependencies = [
  "spin",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rumqttc"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1568e15fab2d546f940ed3a21f48bbbd1c494c90c99c4481339364a497f94a9"
+dependencies = [
+ "bytes",
+ "flume",
+ "futures-util",
+ "log",
+ "rustls-native-certs 0.7.0",
+ "rustls-pemfile 2.1.1",
+ "rustls-webpki 0.102.2",
+ "thiserror",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "url",
 ]
 
 [[package]]
@@ -3363,8 +3533,22 @@ checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99008d7ad0bbbea527ec27bddbc0e432c5b87d8175178cee68d2eec9c4a1813c"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3374,7 +3558,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.1.1",
+ "rustls-pki-types",
  "schannel",
  "security-framework",
 ]
@@ -3389,12 +3586,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f48172685e6ff52a556baa527774f61fcaa884f59daf3375c62a3f1cd2549dab"
+dependencies = [
+ "base64 0.21.7",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "868e20fada228fefaf6b652e00cc73623d54f8171e7352c18bb281571f2d92da"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -3685,11 +3909,14 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spin-app"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0-pre0"
+source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3704,8 +3931,8 @@ dependencies = [
 
 [[package]]
 name = "spin-common"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0-pre0"
+source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
 dependencies = [
  "anyhow",
  "dirs 4.0.0",
@@ -3717,8 +3944,8 @@ dependencies = [
 
 [[package]]
 name = "spin-componentize"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0-pre0"
+source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
 dependencies = [
  "anyhow",
  "wasm-encoder 0.200.0",
@@ -3729,8 +3956,8 @@ dependencies = [
 
 [[package]]
 name = "spin-core"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0-pre0"
+source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3740,6 +3967,7 @@ dependencies = [
  "crossbeam-channel",
  "io-extras",
  "rustix 0.37.27",
+ "spin-telemetry",
  "system-interface",
  "tokio",
  "tracing",
@@ -3750,9 +3978,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin-expressions"
+version = "2.4.0-pre0"
+source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "dotenvy",
+ "once_cell",
+ "serde",
+ "spin-locked-app",
+ "thiserror",
+]
+
+[[package]]
 name = "spin-key-value"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0-pre0"
+source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
 dependencies = [
  "anyhow",
  "lru 0.9.0",
@@ -3766,8 +4008,8 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-azure"
-version = "0.1.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0-pre0"
+source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
 dependencies = [
  "anyhow",
  "azure_data_cosmos",
@@ -3781,8 +4023,8 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-redis"
-version = "0.1.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0-pre0"
+source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
 dependencies = [
  "anyhow",
  "redis",
@@ -3795,8 +4037,8 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-sqlite"
-version = "0.1.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0-pre0"
+source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -3809,8 +4051,8 @@ dependencies = [
 
 [[package]]
 name = "spin-llm"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0-pre0"
+source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -3822,8 +4064,8 @@ dependencies = [
 
 [[package]]
 name = "spin-llm-remote-http"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0-pre0"
+source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
 dependencies = [
  "anyhow",
  "http 0.2.12",
@@ -3833,14 +4075,15 @@ dependencies = [
  "serde_json",
  "spin-core",
  "spin-llm",
+ "spin-telemetry",
  "spin-world",
  "tracing",
 ]
 
 [[package]]
 name = "spin-loader"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0-pre0"
+source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3877,8 +4120,8 @@ dependencies = [
 
 [[package]]
 name = "spin-locked-app"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0-pre0"
+source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3891,8 +4134,8 @@ dependencies = [
 
 [[package]]
 name = "spin-manifest"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0-pre0"
+source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -3906,11 +4149,13 @@ dependencies = [
 
 [[package]]
 name = "spin-outbound-networking"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0-pre0"
+source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
 dependencies = [
  "anyhow",
+ "http 1.1.0",
  "ipnet",
+ "spin-expressions",
  "spin-locked-app",
  "terminal",
  "url",
@@ -3919,8 +4164,8 @@ dependencies = [
 
 [[package]]
 name = "spin-serde"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0-pre0"
+source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
 dependencies = [
  "base64 0.21.7",
  "serde",
@@ -3928,8 +4173,8 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0-pre0"
+source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3942,8 +4187,8 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite-inproc"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0-pre0"
+source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3957,8 +4202,8 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite-libsql"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0-pre0"
+source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3971,9 +4216,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin-telemetry"
+version = "2.4.0-pre0"
+source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
+dependencies = [
+ "anyhow",
+ "http 0.2.12",
+ "http 1.1.0",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "tracing",
+ "tracing-appender",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
 name = "spin-trigger"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0-pre0"
+source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3984,6 +4248,7 @@ dependencies = [
  "indexmap 1.9.3",
  "ipnet",
  "outbound-http",
+ "outbound-mqtt",
  "outbound-mysql",
  "outbound-pg",
  "outbound-redis",
@@ -3994,6 +4259,7 @@ dependencies = [
  "spin-common",
  "spin-componentize",
  "spin-core",
+ "spin-expressions",
  "spin-key-value",
  "spin-key-value-azure",
  "spin-key-value-redis",
@@ -4020,8 +4286,8 @@ dependencies = [
 
 [[package]]
 name = "spin-variables"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0-pre0"
+source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4030,6 +4296,7 @@ dependencies = [
  "serde",
  "spin-app",
  "spin-core",
+ "spin-expressions",
  "spin-world",
  "thiserror",
  "tokio",
@@ -4038,8 +4305,8 @@ dependencies = [
 
 [[package]]
 name = "spin-world"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0-pre0"
+source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
 dependencies = [
  "wasmtime",
 ]
@@ -4195,8 +4462,8 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "2.3.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0-pre0"
+source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
 
 [[package]]
 name = "tar"
@@ -4238,8 +4505,8 @@ dependencies = [
 
 [[package]]
 name = "terminal"
-version = "0.1.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.3.1#22c2ac507add20f82f35e79fb798e8294a49f69a"
+version = "2.4.0-pre0"
+source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
 dependencies = [
  "atty",
  "once_cell",
@@ -4451,7 +4718,29 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.10",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.3",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -4528,6 +4817,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
+dependencies = [
+ "async-trait",
+ "base64 0.21.7",
+ "bytes",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4567,6 +4877,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4599,6 +4921,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-opentelemetry"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9be14ba1bbe4ab79e9229f7f89fab8d120b865859f10527f31c033e599d2284"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4608,12 +4958,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -4631,7 +4984,7 @@ dependencies = [
  "tokio-cron-scheduler",
  "tracing",
  "tracing-subscriber",
- "wasmtime",
+ "wasmtime-wasi",
 ]
 
 [[package]]
@@ -5324,9 +5677,9 @@ dependencies = [
  "http-body 1.0.0",
  "http-body-util",
  "hyper 1.2.0",
- "rustls",
+ "rustls 0.21.10",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tracing",
  "wasmtime",
  "wasmtime-wasi",
@@ -5404,6 +5757,16 @@ name = "web-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5787,6 +6150,12 @@ dependencies = [
  "quote",
  "syn 2.0.55",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 
 [[package]]
 name = "zip"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,14 +17,14 @@ anyhow = "1.0.75"
 async-trait = "0.1"
 clap = { version = "3.1.15", features = ["derive", "env"] }
 serde = "1.0"
-spin-app = { git = "https://github.com/fermyon/spin", tag = "v2.3.1" }
-spin-core = { git = "https://github.com/fermyon/spin", tag = "v2.3.1" }
-spin-trigger = { git = "https://github.com/fermyon/spin", tag = "v2.3.1" }
+spin-app = { git = "https://github.com/fermyon/spin" }
+spin-core = { git = "https://github.com/fermyon/spin" }
+spin-trigger = { git = "https://github.com/fermyon/spin" }
 tokio = { version = "1.23", features = ["full"] }
 tokio-cron-scheduler = "0.9.4"
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3.7", features = ["env-filter"] }
-wasmtime = { version = "18.0.1" }
+wasmtime-wasi = { version = "18.0.1", features = ["tokio"] }
 
 [workspace.dependencies]
 wit-bindgen = "0.16.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ spin-app = { git = "https://github.com/fermyon/spin" }
 spin-core = { git = "https://github.com/fermyon/spin" }
 spin-trigger = { git = "https://github.com/fermyon/spin" }
 tokio = { version = "1.23", features = ["full"] }
-tokio-cron-scheduler = "0.9.4"
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3.7", features = ["env-filter"] }
 wasmtime-wasi = { version = "18.0.1", features = ["tokio"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,24 +1,25 @@
-use std::sync::Arc;
-
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use spin_app::AppComponent;
 use spin_core::Engine;
-use spin_trigger::{
-    cli::NoArgs, EitherInstance, EitherInstancePre, TriggerAppEngine, TriggerExecutor,
-};
+use spin_trigger::TriggerInstancePre;
+use spin_trigger::{cli::NoArgs, TriggerAppEngine, TriggerExecutor};
 
 pub(crate) type RuntimeData = ();
+pub(crate) type Store = spin_core::Store<RuntimeData>;
 
 pub struct CommandTrigger {
     engine: TriggerAppEngine<Self>,
     components: Vec<Component>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Component {
     pub id: String,
+    #[serde(default)]
+    pub executor: CommandExecutorType,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -28,9 +29,29 @@ struct TriggerMetadata {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "lowercase", tag = "type")]
+pub enum CommandExecutorType {
+    #[default]
+    Preview2,
+    Preview1,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CommandTriggerConfig {
     pub component: String,
+    #[serde(default)]
+    pub executor: CommandExecutorType,
+}
+
+pub enum CommandInstancePre {
+    Component(spin_core::InstancePre<RuntimeData>),
+    Module(spin_core::ModuleInstancePre<RuntimeData>),
+}
+
+pub enum CommandInstance {
+    Component(spin_core::Instance),
+    Module(spin_core::ModuleInstance),
 }
 
 #[async_trait]
@@ -39,74 +60,93 @@ impl TriggerExecutor for CommandTrigger {
     type RuntimeData = RuntimeData;
     type TriggerConfig = CommandTriggerConfig;
     type RunConfig = NoArgs;
+    type InstancePre = CommandInstancePre;
 
     async fn new(engine: TriggerAppEngine<Self>) -> Result<Self> {
         let components = engine
             .trigger_configs()
             .map(|(_, config)| Component {
                 id: config.component.clone(),
+                executor: config.executor.clone(),
             })
             .collect();
         Ok(Self { engine, components })
     }
 
     async fn run(self, _config: Self::RunConfig) -> Result<()> {
-        let components = self.components;
-        let engine = Arc::new(self.engine);
-
-        // TODO:
-        // This only uses first component for now.
-        let executor = Executor::new(engine, components[0].clone());
-
-        executor.run().await
+        self.handle().await
     }
+}
 
-    // TODO:
-    // This function assumes WASI P1
+#[async_trait]
+impl TriggerInstancePre<RuntimeData, CommandTriggerConfig> for CommandInstancePre {
+    type Instance = CommandInstance;
+
     async fn instantiate_pre(
-        engine: &Engine<Self::RuntimeData>,
+        engine: &Engine<RuntimeData>,
         component: &AppComponent,
-        _config: &Self::TriggerConfig,
-    ) -> Result<EitherInstancePre<Self::RuntimeData>> {
-        let module = component.load_module(engine).await?;
-        Ok(EitherInstancePre::Module(
-            engine
-                .module_instantiate_pre(&module)
-                .with_context(|| format!("Failed to instantiate component '{}'", component.id()))?,
-        ))
+        config: &CommandTriggerConfig,
+    ) -> Result<CommandInstancePre> {
+        if let CommandExecutorType::Preview1 = &config.executor {
+            let module = component.load_module(engine).await?;
+            Ok(CommandInstancePre::Module(
+                engine.module_instantiate_pre(&module)?,
+            ))
+        } else {
+            let comp = component.load_component(engine).await?;
+            Ok(CommandInstancePre::Component(
+                engine.instantiate_pre(&comp)?,
+            ))
+        }
+    }
+
+    async fn instantiate(&self, store: &mut Store) -> Result<CommandInstance> {
+        match self {
+            CommandInstancePre::Component(pre) => pre
+                .instantiate_async(store)
+                .await
+                .map(CommandInstance::Component),
+            CommandInstancePre::Module(pre) => pre
+                .instantiate_async(store)
+                .await
+                .map(CommandInstance::Module),
+        }
     }
 }
 
-pub struct Executor {
-    pub engine: Arc<TriggerAppEngine<CommandTrigger>>,
-    pub component: Component,
-}
+impl CommandTrigger {
+    pub async fn handle(&self) -> Result<()> {
+        let component = &self.components[0];
+        match component.executor {
+            CommandExecutorType::Preview2 => {
+                let (instance, mut store) = self.engine.prepare_instance(&component.id).await?;
+                let CommandInstance::Component(instance) = instance else {
+                    unreachable!()
+                };
+                let handler =
+                    wasmtime_wasi::preview2::command::Command::new(&mut store, &instance)?;
+                let _ = handler.wasi_cli_run().call_run(store).await?;
+            }
+            CommandExecutorType::Preview1 => {
+                let store_builder = self
+                    .engine
+                    .store_builder(&component.id, spin_core::WasiVersion::Preview1)?;
+                let (instance, mut store) = self
+                    .engine
+                    .prepare_instance_with_store(&component.id, store_builder)
+                    .await?;
 
-impl Executor {
-    pub fn new(engine: Arc<TriggerAppEngine<CommandTrigger>>, component: Component) -> Self {
-        Self { engine, component }
-    }
+                let CommandInstance::Module(instance) = instance else {
+                    unreachable!()
+                };
 
-    pub async fn run(&self) -> Result<()> {
-        let store_builder = self
-            .engine
-            .store_builder(&self.component.id, spin_core::WasiVersion::Preview1)?;
-        let (instance, mut store) = self
-            .engine
-            .prepare_instance_with_store(&self.component.id, store_builder)
-            .await?;
+                let start = instance
+                    .get_func(&mut store, "_start")
+                    .context("Expected component to export _start function")?;
 
-        let EitherInstance::Module(instance) = instance else {
-            unreachable!()
+                let _ = start.call_async(&mut store, &[], &mut []).await?;
+            }
         };
-
-        let start = instance
-            .get_func(&mut store, "")
-            .or_else(|| instance.get_func(&mut store, "_start"))
-            .context("Expected component to export _start function")?;
-
-        let _ = start.call_async(&mut store, &[], &mut []).await?;
-
         Ok(())
     }
 }


### PR DESCRIPTION
~This adds a field to the trigger similar to the http-trigger that needs to be set if running `preview1` components.~

<strike>

```
[[trigger.command]]
component = "sample"
# executor = { type = "preview1" }
``` 

</strike>

This PR adds the ability for the trigger to support preview 2 components along with modules as well. It does it by attempting to load things as a component but falling back to attempting to load modules. The one other constraint it includes is that any preview 2 component supplied must target the `wasi:cli` world.  