### PR TITLE
chore(*): Bump Spin dependency to v2.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1655,12 +1677,27 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "hyper 0.14.28",
- "log",
  "rustls 0.21.10",
- "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
- "webpki-roots",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "399c78f9338483cb7e630c8474b07268983c6bd5acee012e4211f9f7bb21b070"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.28",
+ "log",
+ "rustls 0.22.3",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "webpki-roots 0.26.1",
 ]
 
 [[package]]
@@ -1948,10 +1985,11 @@ dependencies = [
 
 [[package]]
 name = "libsql"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43adbef635c87aaf72870e0a1a8cb39eefcc2c0b0386c75a9436ba6048548f07"
+checksum = "3879a4ed80a245fd4dd8c8fa139245653e86184ed3ab97a6d6ea592045d25793"
 dependencies = [
+ "async-stream",
  "async-trait",
  "base64 0.21.7",
  "bitflags 2.5.0",
@@ -1960,14 +1998,28 @@ dependencies = [
  "futures",
  "http 0.2.12",
  "hyper 0.14.28",
- "hyper-rustls",
+ "hyper-rustls 0.25.0",
+ "libsql-hrana",
  "libsql-sqlite3-parser",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
+ "tokio-util 0.7.10",
  "tower",
  "tracing",
+]
+
+[[package]]
+name = "libsql-hrana"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40f256c5c98e84808e067133253471d6f5961c670f0127150694210fb8e6116a"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "prost",
+ "serde",
 ]
 
 [[package]]
@@ -2687,8 +2739,8 @@ dependencies = [
 
 [[package]]
 name = "outbound-http"
-version = "2.4.0-pre0"
-source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "http 0.2.12",
@@ -2706,8 +2758,8 @@ dependencies = [
 
 [[package]]
 name = "outbound-mqtt"
-version = "2.4.0-pre0"
-source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "rumqttc",
@@ -2723,8 +2775,8 @@ dependencies = [
 
 [[package]]
 name = "outbound-mysql"
-version = "2.4.0-pre0"
-source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "flate2",
@@ -2743,8 +2795,8 @@ dependencies = [
 
 [[package]]
 name = "outbound-pg"
-version = "2.4.0-pre0"
-source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "native-tls",
@@ -2762,8 +2814,8 @@ dependencies = [
 
 [[package]]
 name = "outbound-redis"
-version = "2.4.0-pre0"
-source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "redis",
@@ -3322,7 +3374,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
- "hyper-rustls",
+ "hyper-rustls 0.24.2",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -3349,7 +3401,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.25.4",
  "winreg",
 ]
 
@@ -3378,7 +3430,7 @@ dependencies = [
  "flume",
  "futures-util",
  "log",
- "rustls-native-certs 0.7.0",
+ "rustls-native-certs",
  "rustls-pemfile 2.1.1",
  "rustls-webpki 0.102.2",
  "thiserror",
@@ -3509,18 +3561,6 @@ dependencies = [
  "rustls-webpki 0.102.2",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile 1.0.4",
- "schannel",
- "security-framework",
 ]
 
 [[package]]
@@ -3875,8 +3915,8 @@ dependencies = [
 
 [[package]]
 name = "spin-app"
-version = "2.4.0-pre0"
-source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3891,8 +3931,8 @@ dependencies = [
 
 [[package]]
 name = "spin-common"
-version = "2.4.0-pre0"
-source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "dirs 4.0.0",
@@ -3904,8 +3944,8 @@ dependencies = [
 
 [[package]]
 name = "spin-componentize"
-version = "2.4.0-pre0"
-source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "wasm-encoder 0.200.0",
@@ -3916,8 +3956,8 @@ dependencies = [
 
 [[package]]
 name = "spin-core"
-version = "2.4.0-pre0"
-source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3939,8 +3979,8 @@ dependencies = [
 
 [[package]]
 name = "spin-expressions"
-version = "2.4.0-pre0"
-source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3953,8 +3993,8 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value"
-version = "2.4.0-pre0"
-source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "lru 0.9.0",
@@ -3968,8 +4008,8 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-azure"
-version = "2.4.0-pre0"
-source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "azure_data_cosmos",
@@ -3983,8 +4023,8 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-redis"
-version = "2.4.0-pre0"
-source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "redis",
@@ -3997,8 +4037,8 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-sqlite"
-version = "2.4.0-pre0"
-source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -4011,8 +4051,8 @@ dependencies = [
 
 [[package]]
 name = "spin-llm"
-version = "2.4.0-pre0"
-source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -4024,8 +4064,8 @@ dependencies = [
 
 [[package]]
 name = "spin-llm-remote-http"
-version = "2.4.0-pre0"
-source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "http 0.2.12",
@@ -4042,8 +4082,8 @@ dependencies = [
 
 [[package]]
 name = "spin-loader"
-version = "2.4.0-pre0"
-source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4080,8 +4120,8 @@ dependencies = [
 
 [[package]]
 name = "spin-locked-app"
-version = "2.4.0-pre0"
-source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4094,8 +4134,8 @@ dependencies = [
 
 [[package]]
 name = "spin-manifest"
-version = "2.4.0-pre0"
-source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -4109,8 +4149,8 @@ dependencies = [
 
 [[package]]
 name = "spin-outbound-networking"
-version = "2.4.0-pre0"
-source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "http 1.1.0",
@@ -4124,8 +4164,8 @@ dependencies = [
 
 [[package]]
 name = "spin-serde"
-version = "2.4.0-pre0"
-source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "base64 0.21.7",
  "serde",
@@ -4133,8 +4173,8 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite"
-version = "2.4.0-pre0"
-source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4147,8 +4187,8 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite-inproc"
-version = "2.4.0-pre0"
-source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4162,8 +4202,8 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite-libsql"
-version = "2.4.0-pre0"
-source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4177,8 +4217,8 @@ dependencies = [
 
 [[package]]
 name = "spin-telemetry"
-version = "2.4.0-pre0"
-source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "http 0.2.12",
@@ -4196,8 +4236,8 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger"
-version = "2.4.0-pre0"
-source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4246,8 +4286,8 @@ dependencies = [
 
 [[package]]
 name = "spin-variables"
-version = "2.4.0-pre0"
-source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4265,8 +4305,8 @@ dependencies = [
 
 [[package]]
 name = "spin-world"
-version = "2.4.0-pre0"
-source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "wasmtime",
 ]
@@ -4422,8 +4462,8 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "2.4.0-pre0"
-source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 
 [[package]]
 name = "tar"
@@ -4465,8 +4505,8 @@ dependencies = [
 
 [[package]]
 name = "terminal"
-version = "2.4.0-pre0"
-source = "git+https://github.com/fermyon/spin#a400e3fe702694a042e4c9de814445b0f99daef4"
+version = "2.4.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.4.0#11728244cc4737378d9b2d6f55965e4930ada425"
 dependencies = [
  "atty",
  "once_cell",
@@ -5627,7 +5667,7 @@ dependencies = [
  "tracing",
  "wasmtime",
  "wasmtime-wasi",
- "webpki-roots",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]
@@ -5721,6 +5761,15 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "whoami"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ anyhow = "1.0.75"
 async-trait = "0.1"
 clap = { version = "3.1.15", features = ["derive", "env"] }
 serde = "1.0"
-spin-app = { git = "https://github.com/fermyon/spin" }
-spin-core = { git = "https://github.com/fermyon/spin" }
-spin-trigger = { git = "https://github.com/fermyon/spin" }
+spin-app = { git = "https://github.com/fermyon/spin", tag = "v2.4.0" }
+spin-core = { git = "https://github.com/fermyon/spin", tag = "v2.4.0"  }
+spin-trigger = { git = "https://github.com/fermyon/spin", tag = "v2.4.0" }
 tokio = { version = "1.23", features = ["full"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3.7", features = ["env-filter"] }


### PR DESCRIPTION
This commit updates the Spin dependency to v2.4.0

Signed-off-by: Radu Matei <radu@fermyon.com>
