### PR TITLE
allow passing in the cli args to the components as env args

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub struct Component {
 #[clap(trailing_var_arg(true))]
 pub struct CliArgs {
     #[clap(multiple_values(true), allow_hyphen_values(true))]
-    guest_args: Vec<String>,
+    pub guest_args: Vec<String>,
 }
 
 impl CliArgs {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,11 @@
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
+use clap::Args;
 use serde::{Deserialize, Serialize};
 use spin_app::AppComponent;
 use spin_core::Engine;
 use spin_trigger::TriggerInstancePre;
-use spin_trigger::{cli::NoArgs, TriggerAppEngine, TriggerExecutor};
+use spin_trigger::{TriggerAppEngine, TriggerExecutor};
 
 type RuntimeData = ();
 type Store = spin_core::Store<RuntimeData>;
@@ -20,10 +21,27 @@ pub struct Component {
     pub id: String,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-struct TriggerMetadata {
-    pub r#type: String,
+#[derive(Args)]
+pub struct CliArgs {
+    args: Vec<String>,
+}
+
+impl CliArgs {
+    fn apply_args_to_store(
+        &self,
+        component_id: &str,
+        store_builder: &mut spin_core::StoreBuilder,
+    ) -> Result<()> {
+        // Insert the component id as the first argument as the command name
+        let args = vec![component_id]
+            .into_iter()
+            .chain(self.args.iter().map(|arg| &**arg))
+            .collect::<Vec<&str>>();
+
+        store_builder.args(args)?;
+
+        Ok(())
+    }
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -47,7 +65,7 @@ impl TriggerExecutor for CommandTrigger {
     const TRIGGER_TYPE: &'static str = "command";
     type RuntimeData = RuntimeData;
     type TriggerConfig = CommandTriggerConfig;
-    type RunConfig = NoArgs;
+    type RunConfig = CliArgs;
     type InstancePre = CommandInstancePre;
 
     async fn new(engine: TriggerAppEngine<Self>) -> Result<Self> {
@@ -60,8 +78,8 @@ impl TriggerExecutor for CommandTrigger {
         Ok(Self { engine, components })
     }
 
-    async fn run(self, _config: Self::RunConfig) -> Result<()> {
-        self.handle().await
+    async fn run(self, config: Self::RunConfig) -> Result<()> {
+        self.handle(config).await
     }
 }
 
@@ -105,9 +123,18 @@ impl TriggerInstancePre<RuntimeData, CommandTriggerConfig> for CommandInstancePr
 }
 
 impl CommandTrigger {
-    pub async fn handle(&self) -> Result<()> {
+    pub async fn handle(&self, args: CliArgs) -> Result<()> {
         let component = &self.components[0];
-        let (instance, mut store) = self.engine.prepare_instance(&component.id).await?;
+        let mut store_builder = self
+            .engine
+            .store_builder(&component.id, spin_core::WasiVersion::Preview2)?;
+
+        args.apply_args_to_store(&component.id, &mut store_builder)?;
+
+        let (instance, mut store) = self
+            .engine
+            .prepare_instance_with_store(&component.id, store_builder)
+            .await?;
         match instance {
             CommandInstance::Component(instance) => {
                 let handler = wasmtime_wasi::preview2::command::Command::new(&mut store, &instance)
@@ -117,9 +144,12 @@ impl CommandTrigger {
             CommandInstance::Module(_) => {
                 // Toss the commandInstance we have and create a new one as the
                 // associated store will be a preview2 store
-                let store_builder = self
+                let mut store_builder = self
                     .engine
                     .store_builder(&component.id, spin_core::WasiVersion::Preview1)?;
+
+                args.apply_args_to_store(&component.id, &mut store_builder)?;
+
                 let (instance, mut store) = self
                     .engine
                     .prepare_instance_with_store(&component.id, store_builder)


### PR DESCRIPTION
This PR enables passing in the CLI args passed to the component with the component ID used as the command name. eg:

<strike>

Rust code
```rust 
#[allow(warnings)]
mod bindings;

fn main() {
    let args = std::env::args();
    for arg in args {
        println!("{arg}")
    }
}

```

```bash
$ spin up these are some args
pin up this is something                     
Logging component stdio to ".spin/logs/"
sample # this is the component id
these
are
some
args 
```
</strike>

The updated behavior is describe in https://github.com/fermyon/spin-trigger-command/pull/4#issuecomment-2035640323