### PR TITLE
Add command-rust template

### DIFF
--- a/templates/command-rust/content/.gitignore
+++ b/templates/command-rust/content/.gitignore
@@ -1,0 +1,2 @@
+target/
+.spin/

--- a/templates/command-rust/content/Cargo.toml.tmpl
+++ b/templates/command-rust/content/Cargo.toml.tmpl
@@ -1,0 +1,19 @@
+[package]
+name = "{{project-name | kebab_case}}"
+authors = ["{{authors}}"]
+description = "{{project-description}}"
+version = "0.1.0"
+edition = "2021"
+
+[package.metadata.component]
+package = "component:{{project-name | kebab_case}}"
+
+[package.metadata.component.dependencies]
+
+[dependencies]
+anyhow = "1"
+spin-sdk = "3.0.1"
+spin-executor =  "3.0.1"
+wit-bindgen-rt = { version = "0.26.0", features = ["bitflags"] }
+
+[workspace]

--- a/templates/command-rust/content/spin.toml
+++ b/templates/command-rust/content/spin.toml
@@ -1,0 +1,18 @@
+spin_manifest_version = 2
+
+[application]
+name = "{{project-name | kebab_case}}"
+version = "0.1.0"
+authors = ["{{authors}}"]
+description = "{{project-description}}"
+
+[[trigger.command]]
+component = "{{project-name | kebab_case}}"
+
+[component.{{project-name | kebab_case}}]
+source = "target/wasm32-wasi/release/{{project-name | kebab_case}}.wasm"
+allowed_outbound_hosts = []
+
+[component.{{project-name | kebab_case}}.build]
+command = "cargo component build --target wasm32-wasi --release"
+watch = ["src/**/*.rs", "Cargo.toml"]

--- a/templates/command-rust/content/src/main.rs
+++ b/templates/command-rust/content/src/main.rs
@@ -1,0 +1,6 @@
+#[allow(warnings)]
+mod bindings;
+
+fn main() {
+    println!("Hello, Fermyon!");
+}

--- a/templates/command-rust/metadata/snippets/component.txt
+++ b/templates/command-rust/metadata/snippets/component.txt
@@ -1,0 +1,11 @@
+[[trigger.command]]
+component = "{{project-name | kebab_case}}"
+
+[component.{{project-name | kebab_case}}]
+source = "{{ output-path }}/target/wasm32-wasi/release/{{project-name | kebab_case}}.wasm"
+allowed_outbound_hosts = []
+
+[component.{{project-name | kebab_case}}.build]
+command = "cargo component build --target wasm32-wasi --release"
+workdir = "{{ output-path }}"
+watch = ["src/**/*.rs", "Cargo.toml"]

--- a/templates/command-rust/metadata/spin-template.toml
+++ b/templates/command-rust/metadata/spin-template.toml
@@ -1,0 +1,12 @@
+manifest_version = "1"
+id = "command-rust"
+description = "Command handler using Rust"
+tags = ["command", "rust"]
+
+[add_component]
+skip_files = ["spin.toml"]
+[add_component.snippets]
+component = "component.txt"
+
+[parameters]
+project-description = { type = "string", prompt = "Description", default = "" }


### PR DESCRIPTION
This commit adds the command-rust template to the plugin allowing users to quickly create a new Spin App using the command trigger. Support for `spin add` is in there as well

#20 