### PR TITLE
Fixing the Installation instruction in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The trigger is installed as a Spin plugin. It can be installed from a release or
 To install from a release, reference a plugin manifest from a [release](https://github.com/fermyon/spin-trigger-command/releases). For example, to install the canary release:
 
 ```sh
-spin plugins install --from https://github.com/fermyon/spin-trigger-command/releases/download/canary/trigger-command.json
+spin plugins install --url https://github.com/fermyon/spin-trigger-command/releases/download/canary/trigger-command.json
 ```
 
 Alternatively, use the `spin pluginify` plugin to install from a fresh build. This will use the pluginify manifest (`spin-pluginify.toml`) to package the plugin and proceed to install it:


### PR DESCRIPTION
Fixing this error:

```console
$ spin plugins install --from https://github.com/fermyon/spin-trigger-command/releases/download/canary/trigger-command.json
error: Found argument '--from' which wasn't expected, or isn't valid in this context
```