### PR TITLE
chore(spin-pluginify.toml): add description

### DIFF
--- a/spin-pluginify.toml
+++ b/spin-pluginify.toml
@@ -1,4 +1,5 @@
 name = "trigger-command"
+description = "A Spin trigger that executes the WASI main function of a component."
 version = "0.1"
 spin_compatibility = ">=2.0"
 license = "Apache-2.0"


### PR DESCRIPTION
A description will be necessary to [pass plugin manifest validation](https://github.com/fermyon/spin-plugins?tab=readme-ov-file#validating-plugin-schemas) when we'd like to add this to the [spin-plugins](https://github.com/fermyon/spin-plugins) repo.

Please advise on ideal wording.