### PR TITLE
docs(README.md): installation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,24 @@ This is a very simple Spin trigger that executes the WASI main function.
 
 The trigger is installed as a Spin plugin. It can be installed from a release or build.
 
-To install from a release, reference a plugin manifest from a [release](https://github.com/fermyon/spin-trigger-command/releases). For example, to install the canary release:
+## Install the latest version of the plugin
+
+The latest stable release of the command trigger plugin can be installed like so:
+
+```sh
+spin plugins update
+spin plugin install trigger-command
+```
+
+## Install the canary version of the plugin
+
+The canary release of the command trigger plugin represents the most recent commits on `main` and may not be stable, with some features still in progress.
 
 ```sh
 spin plugins install --url https://github.com/fermyon/spin-trigger-command/releases/download/canary/trigger-command.json
 ```
+
+## Install from a local build
 
 Alternatively, use the `spin pluginify` plugin to install from a fresh build. This will use the pluginify manifest (`spin-pluginify.toml`) to package the plugin and proceed to install it:
 


### PR DESCRIPTION
Update installation methods now that this plugin is listed in the [spin-plugins repo](https://github.com/fermyon/spin-plugins).

Along with https://github.com/fermyon/spin-plugins/pull/62, this closes https://github.com/fermyon/spin-trigger-command/issues/23.