### PR TITLE
chore(.github): bump artifact actions to v4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -93,7 +93,7 @@ jobs:
       - name: Pluginify plugin binary
         run: spin pluginify --arch ${{ matrix.config.arch }}
       - name: Archive pluginified
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.PROGRAM_NAME}}-${{ matrix.config.os }}-${{ matrix.config.arch }}
           path: |
@@ -128,7 +128,9 @@ jobs:
         run: echo "RELEASE_VERSION=precanary" >> $GITHUB_ENV
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ${{ env.PROGRAM_NAME}}-*
       - name: Display structure of downloaded files
         run: ls -R
       - name: pluginify it


### PR DESCRIPTION
- Bumps the artifact actions to v4 per https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/