### PR TITLE
Fix `command-rust` template and bump `wit-bindgen-rt` dependency

### DIFF
--- a/templates/command-rust/content/Cargo.toml.tmpl
+++ b/templates/command-rust/content/Cargo.toml.tmpl
@@ -14,6 +14,6 @@ package = "component:{{project-name | kebab_case}}"
 anyhow = "1"
 spin-sdk = "3.0.1"
 spin-executor =  "3.0.1"
-wit-bindgen-rt = { version = "0.26.0", features = ["bitflags"] }
+wit-bindgen-rt = { version = "0.34.0", features = ["bitflags"] }
 
 [workspace]

--- a/templates/command-rust/content/src/main.rs
+++ b/templates/command-rust/content/src/main.rs
@@ -1,6 +1,3 @@
-#[allow(warnings)]
-mod bindings;
-
 fn main() {
     println!("Hello, Fermyon!");
 }


### PR DESCRIPTION
When using the `command-rust` template with a recent version of Spin - I tested with spin `2.7.0` and most recent `canary` (on Oct 30. 2024) - compilation to Wasm fails because `bindings.rs` is no longer generated during build.

The PR removes the `mod bindings;` declaration from `main.rs`. Additionally, the `wit-bindgen-rt` dependency is bumped to the most recent release (`0.34.0`).