### PR TITLE
chore: use Spin v3.1.1 dependencies

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.79
+          toolchain: 1.81
         
       - name: Install dependencies
         run: |
@@ -68,7 +68,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.79
+          toolchain: 1.81
           targets: ${{ matrix.config.target }}
       - name: Install Spin
         uses: rajatjindal/setup-actions/spin@main

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-once-cell"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288f83726785267c6f2ef073a3d83dc3f9b81464e9f99898240cced85fce35a"
+
+[[package]]
 name = "async-process"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,6 +268,329 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "aws-config"
+version = "1.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d1c2c88936a73c699225d0bc00684a534166b0cebc2659c3cdf08de8edc64c"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand 2.0.2",
+ "hex",
+ "http 0.2.12",
+ "ring",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60e8f6b615cb5fc60a98132268508ad104310f0cfb25a1c22eee76efdf9154da"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16d1aa50accc11a4b4d5c50f7fb81cc0cf60328259c587d0e6b0f11385bde46"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-dynamodb"
+version = "1.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "676f55a6ce7b280b592356e9b8c793631561ccd46c3f1928f69113ca9b518d0f"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand 2.0.2",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1605dc0bf9f0a4b05b451441a17fcb0bda229db384f23bf5cead3adbab0664ac"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59f3f73466ff24f6ad109095e0f3f2c830bfb4cd6c8b12f744c8e61ebf4d3ba1"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "249b2acaa8e02fd4718705a9494e3eb633637139aa4bb09d70965b0448e865db"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d3820e0c08d0737872ff3c7c1f21ebbb6693d832312d6152bf18ef50a5471c2"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.1.0",
+ "once_cell",
+ "percent-encoding",
+ "sha2",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427cb637d15d63d6f9aae26358e1c9a9c09d5aa490d64b09354c8217cfef0f28"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.60.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8bc3e8fdc6b8d07d976e301c02fe553f72a39b7a9fea820e023268467d7ab6"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4e69cc50921eb913c6b662f8d909131bb3e6ad6cb6090d3a39b66fc5c52095"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fbd61ceb3fe8a1cb7352e42689cec5335833cd9f94103a61e98f9bb61c64bb"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a05dd41a70fc74051758ee75b5c4db2c0ca070ed9229c3df50e9475cda1cb985"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand 2.0.2",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "httparse",
+ "hyper 0.14.28",
+ "hyper-rustls 0.24.2",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "rustls 0.21.12",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92165296a47a812b267b4f41032ff8069ab7ff783696d217f0994a0d7ab585cd"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.1.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38ddc9bd6c28aeb303477170ddd183760a956a03e083b3902a990238a7e3792d"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.1.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab0b0166827aa700d3dc519f72f8b3a91c35d0b8d042dc5d643a91e6f80648fc"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5221b91b3e441e6675310829fd8984801b772cb1546ef6c0e54dec9f1ac13fef"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
 
 [[package]]
 name = "axum"
@@ -423,6 +752,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,6 +841,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
 ]
 
 [[package]]
@@ -1171,6 +1520,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1597,12 +1957,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1747,7 +2122,9 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "hyper 0.14.28",
+ "log",
  "rustls 0.21.12",
+ "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
 ]
@@ -1763,7 +2140,7 @@ dependencies = [
  "hyper 0.14.28",
  "log",
  "rustls 0.22.4",
- "rustls-native-certs",
+ "rustls-native-certs 0.7.3",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.25.0",
@@ -2504,23 +2881,35 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.25.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803801d3d3b71cd026851a53f974ea03df3d179cb758b260136a6c9e22e196af"
+checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
 dependencies = [
  "futures-core",
  "futures-sink",
  "js-sys",
- "once_cell",
  "pin-project-lite",
  "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5feffc321035ad94088a7e5333abb4d84a8726e54a802e736ce9dd7237e85b"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d8c2b76e5f7848a289aa9666dbe56b16f8a22a4c5246ef37a14941818d2913"
+checksum = "10a8a7f5f6ba7c1b286c2fbca0454eaba116f63bbe69ed250b642d36fbb04d80"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2531,9 +2920,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "596b1719b3cab83addb20bcbffdf21575279d9436d9ccccfe651a3bf0ab5ab06"
+checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
 dependencies = [
  "async-trait",
  "futures-core",
@@ -2547,13 +2936,14 @@ dependencies = [
  "thiserror",
  "tokio",
  "tonic",
+ "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c43620e8f93359eb7e627a3b16ee92d8585774986f24f2ab010817426c5ce61"
+checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -2563,16 +2953,15 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.25.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0da0d6b47a3dbc6e9c9e36a0520e25cf943e046843818faaa3f87365a548c82"
+checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
 dependencies = [
  "async-trait",
  "futures-channel",
  "futures-executor",
  "futures-util",
  "glob",
- "once_cell",
  "opentelemetry",
  "percent-encoding",
  "rand 0.8.5",
@@ -2580,6 +2969,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tracing",
 ]
 
 [[package]]
@@ -2593,6 +2983,12 @@ name = "os_str_bytes"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+
+[[package]]
+name = "outref"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
 
 [[package]]
 name = "overload"
@@ -3141,6 +3537,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3265,7 +3667,7 @@ dependencies = [
  "flume",
  "futures-util",
  "log",
- "rustls-native-certs",
+ "rustls-native-certs 0.7.3",
  "rustls-pemfile 2.1.3",
  "rustls-webpki 0.102.8",
  "thiserror",
@@ -3403,6 +3805,18 @@ dependencies = [
  "rustls-webpki 0.102.8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -3743,8 +4157,8 @@ dependencies = [
 
 [[package]]
 name = "spin-app"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "anyhow",
  "serde",
@@ -3754,8 +4168,8 @@ dependencies = [
 
 [[package]]
 name = "spin-common"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -3767,8 +4181,8 @@ dependencies = [
 
 [[package]]
 name = "spin-componentize"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "anyhow",
  "tracing",
@@ -3781,8 +4195,8 @@ dependencies = [
 
 [[package]]
 name = "spin-compose"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3796,8 +4210,8 @@ dependencies = [
 
 [[package]]
 name = "spin-core"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3807,8 +4221,8 @@ dependencies = [
 
 [[package]]
 name = "spin-expressions"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3819,8 +4233,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-key-value"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "anyhow",
  "lru",
@@ -3838,8 +4252,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-llm"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3847,6 +4261,7 @@ dependencies = [
  "spin-factors",
  "spin-llm-remote-http",
  "spin-locked-app",
+ "spin-telemetry",
  "spin-world",
  "tokio",
  "toml",
@@ -3856,8 +4271,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-http"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "anyhow",
  "http 1.1.0",
@@ -3880,8 +4295,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-mqtt"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "anyhow",
  "rumqttc",
@@ -3896,8 +4311,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-mysql"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "anyhow",
  "mysql_async",
@@ -3913,8 +4328,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-networking"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -3939,8 +4354,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-pg"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3958,8 +4373,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-outbound-redis"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "anyhow",
  "redis 0.25.4",
@@ -3973,8 +4388,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-sqlite"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "async-trait",
  "spin-factors",
@@ -3987,8 +4402,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-variables"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "spin-expressions",
  "spin-factors",
@@ -3998,8 +4413,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factor-wasi"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4012,8 +4427,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factors"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "anyhow",
  "serde",
@@ -4026,8 +4441,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factors-derive"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4036,8 +4451,8 @@ dependencies = [
 
 [[package]]
 name = "spin-factors-executor"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "anyhow",
  "spin-app",
@@ -4046,9 +4461,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin-key-value-aws"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
+dependencies = [
+ "anyhow",
+ "async-once-cell",
+ "aws-config",
+ "aws-credential-types",
+ "aws-sdk-dynamodb",
+ "serde",
+ "spin-core",
+ "spin-factor-key-value",
+]
+
+[[package]]
 name = "spin-key-value-azure"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "anyhow",
  "azure_core",
@@ -4062,8 +4492,8 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-redis"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "anyhow",
  "redis 0.27.5",
@@ -4076,8 +4506,8 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value-spin"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "anyhow",
  "rusqlite",
@@ -4090,8 +4520,8 @@ dependencies = [
 
 [[package]]
 name = "spin-llm-remote-http"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "anyhow",
  "reqwest 0.12.5",
@@ -4104,8 +4534,8 @@ dependencies = [
 
 [[package]]
 name = "spin-locked-app"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4117,8 +4547,8 @@ dependencies = [
 
 [[package]]
 name = "spin-manifest"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -4134,13 +4564,13 @@ dependencies = [
 
 [[package]]
 name = "spin-resource-table"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 
 [[package]]
 name = "spin-runtime-config"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "anyhow",
  "spin-common",
@@ -4156,6 +4586,7 @@ dependencies = [
  "spin-factor-variables",
  "spin-factor-wasi",
  "spin-factors",
+ "spin-key-value-aws",
  "spin-key-value-azure",
  "spin-key-value-redis",
  "spin-key-value-spin",
@@ -4167,8 +4598,8 @@ dependencies = [
 
 [[package]]
 name = "spin-runtime-factors"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "anyhow",
  "clap",
@@ -4194,8 +4625,8 @@ dependencies = [
 
 [[package]]
 name = "spin-serde"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4206,8 +4637,8 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "serde",
  "spin-factor-sqlite",
@@ -4219,8 +4650,8 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite-inproc"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4232,8 +4663,8 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite-libsql"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4245,13 +4676,14 @@ dependencies = [
 
 [[package]]
 name = "spin-telemetry"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "anyhow",
  "http 0.2.12",
  "http 1.1.0",
  "opentelemetry",
+ "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "terminal",
@@ -4262,8 +4694,8 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "anyhow",
  "clap",
@@ -4289,8 +4721,8 @@ dependencies = [
 
 [[package]]
 name = "spin-variables"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "azure_core",
  "azure_identity",
@@ -4308,8 +4740,8 @@ dependencies = [
 
 [[package]]
 name = "spin-world"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "async-trait",
  "wasmtime",
@@ -4478,8 +4910,8 @@ dependencies = [
 
 [[package]]
 name = "terminal"
-version = "3.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v3.0.0#737778e9d7dc1a7f590a398d2734ff0cc91002f0"
+version = "3.1.1"
+source = "git+https://github.com/fermyon/spin?tag=v3.1.1#aa919ce36a5f6c45e6c9b66bcd94657281f44bf3"
 dependencies = [
  "termcolor",
 ]
@@ -4824,9 +5256,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.26.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eabc56d23707ad55ba2a0750fc24767125d5a0f51993ba41ad2c441cc7b8dea"
+checksum = "97a971f6058498b5c0f1affa23e7ea202057a7301dbff68e968b2d578bcbd053"
 dependencies = [
  "js-sys",
  "once_cell",
@@ -4885,7 +5317,6 @@ dependencies = [
  "spin-trigger",
  "tokio",
  "tracing",
- "wasmtime-wasi",
 ]
 
 [[package]]
@@ -5038,6 +5469,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wac-graph"
@@ -5234,17 +5671,21 @@ dependencies = [
 
 [[package]]
 name = "wasm-pkg-common"
-version = "0.4.1"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca7a687d110f68a65227a644c7040c7720220e8cb0bb8c803e2b5dcb7fd72468"
+checksum = "b14acb8e490839c93364c23716feb9af0dd93e0638b8b5e083b1d0803b7ea595"
 dependencies = [
  "anyhow",
- "dirs 5.0.1",
+ "bytes",
+ "etcetera",
+ "futures-util",
  "http 1.1.0",
  "semver",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror",
+ "tokio",
  "toml",
  "tracing",
 ]
@@ -6014,6 +6455,12 @@ dependencies = [
  "thiserror",
  "wast 35.0.2",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "trigger-command"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
-rust-version = "1.76"
+rust-version = "1.81"
 
 [workspace.package]
 version = "0.2.0"
@@ -16,20 +16,17 @@ edition = "2021"
 anyhow = "1.0"
 clap = { version = "3.1.15", features = ["derive", "env"] }
 serde = "1.0"
-spin-trigger = { git = "https://github.com/fermyon/spin", tag = "v3.0.0" }
-spin-core = { git = "https://github.com/fermyon/spin", tag = "v3.0.0" }
-spin-telemetry = { git = "https://github.com/fermyon/spin", tag = "v3.0.0" }
-spin-factors = { git = "https://github.com/fermyon/spin", tag = "v3.0.0" }
-spin-factor-wasi = { git = "https://github.com/fermyon/spin", tag = "v3.0.0" }
-spin-runtime-factors = { git = "https://github.com/fermyon/spin", tag = "v3.0.0" }
+spin-trigger = { git = "https://github.com/fermyon/spin", tag = "v3.1.1" }
+spin-core = { git = "https://github.com/fermyon/spin", tag = "v3.1.1" }
+spin-telemetry = { git = "https://github.com/fermyon/spin", tag = "v3.1.1" }
+spin-factors = { git = "https://github.com/fermyon/spin", tag = "v3.1.1" }
+spin-factor-wasi = { git = "https://github.com/fermyon/spin", tag = "v3.1.1" }
+spin-runtime-factors = { git = "https://github.com/fermyon/spin", tag = "v3.1.1" }
 tokio = { version = "1.38", features = ["rt", "macros"] }
 tracing = { version = "0.1", features = ["log"] }
-wasmtime-wasi = "25.0.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # This needs to be an explicit dependency to enable
 # '--features openssl/vendored', which is used for Linux releases.
 openssl = { version = "0.10" }
 
-[workspace.dependencies]
-wit-bindgen = "0.16.0"


### PR DESCRIPTION
Also bumps Rust toolchain to minimum required and removes unused dependencies