### PR TITLE
Release Command Trigger v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5303,7 +5303,7 @@ dependencies = [
 
 [[package]]
 name = "trigger-command"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = { workspace = true }
 rust-version = "1.81"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Radu Matei <radu@fermyon.com>"]
 edition = "2021"
 

--- a/spin-pluginify.toml
+++ b/spin-pluginify.toml
@@ -1,6 +1,6 @@
 name = "trigger-command"
 description = "A Spin trigger that executes the WASI main function of a component."
-version = "0.2"
+version = "0.2.1"
 spin_compatibility = ">=2.0"
 license = "Apache-2.0"
 package = "./target/release/trigger-command"


### PR DESCRIPTION
New release of the trigger that points to Spin v3.1.1 dependencies

Fulfills steps 1-3 of the [release process](https://github.com/fermyon/spin-trigger-command/blob/main/release-process.md)